### PR TITLE
Identifiers and versions

### DIFF
--- a/common-definitions.md
+++ b/common-definitions.md
@@ -4,16 +4,15 @@
 
 Identifier :: /[_A-Za-z][_0-9A-Za-z]*/
 
-
 ## Profile Identifier
 
 ProfileIdentifier : ProfileScope? ProfileName
 
-ProfileScope : NameIdentifier `/`
+ProfileScope : DocumentNameIdentifier `/`
 
-ProfileName : NameIdentifier
+ProfileName : DocumentNameIdentifier
 
-NameIdentifier :: /[a-z][a-z0-9_-]*/
+DocumentNameIdentifier :: /[a-z][a-z0-9_-]*/
 
 Identifier of a profile regardless its version.
 
@@ -56,6 +55,10 @@ Profile identifier used in maps does not include the patch number.
 ```example
 starwars/character-information@1.1
 ```
+
+## Provider Identifier
+
+ProviderIdentifier : DocumentNameIdentifier
 
 ## URL Value
 

--- a/map-spec.md
+++ b/map-spec.md
@@ -5,23 +5,40 @@ Superface Map
 
 **Introduction**
 
-Superface map is a format describing one concrete implementation of a Superface profile. It essentially maps the application (business) semantics into concrete interface implementation.
+Superface map is a format describing one concrete implementation of a Superface profile. It essentially maps the application (business) semantics into provider's interface implementation.
 
 # Map Document
 
-MapDocument : Profile Provider Map+ Operation*
+MapDocument : Profile Provider Variant? Map+ Operation*
 
-Profile : `profile` = ProfileId
+Profile : `profile` = `"` MapProfileIdentifier `"`
 
-ProfileId : URLValue
+Provider : `provider` = `"` ProviderIdentifier `"`
 
-Provider : `provider` = ProviderId
+Variant : DocumentNameIdentifier
 
-ProviderId : URLValue
+Defines a document that maps a profile into a particular provider's API. At minimum, the map document consists of the profile and provider identifiers and a profile use-case map. 
+
+Optionally, map document may specify a variant. {Variant} allows for mutliple maps for the same {MapProfileIdentifier} and {ProviderIdentifier}.
+
 
 ```example
-profile = "http://superface.ai/profile/conversation/SendMessage"
-provider = "http://superface.ai/directory/MyTelcoCompany"
+profile = "conversation/send-message"
+provider = "some-telco-api"
+
+map SendMessage {
+  ...
+}
+
+map RetrieveMessageStatus {
+  ...
+}
+```
+
+```example
+profile = "conversation/send-message"
+provider = "some-telco-api"
+variant = "my-bugfix"
 
 map SendMessage {
   ...

--- a/profile-spec.md
+++ b/profile-spec.md
@@ -25,9 +25,9 @@ When submitted to a profile store, the profile must be assigned a globally uniqu
 
 ProfileDocument : Description? ProfileName ProfileVersion? Usecase+ NamedModel* NamedField*
 
-ProfileName : `name` = ProfileIdentifier
+ProfileName : `name` = `"` ProfileIdentifier `"`
 
-ProfileVersion : `version` = SemanticVersion
+ProfileVersion : `version` = `"` SemanticVersion `"`
 
 ```example
 name = "meteo/get-weather"


### PR DESCRIPTION
Following our discussion this PR proposes the changes to both profile and map spec as follow:

# Profile
- rename `profile` to `name`
- introduce `version`
- change value of `profile` (`name`) from URL to scoped profile identifier

# Map 
- change value of `profile` to scoped profile identifier with major.minor version
- introduce `variant`
