### PR TITLE
Make Profile Version Required

### DIFF
--- a/profile-spec.md
+++ b/profile-spec.md
@@ -23,7 +23,7 @@ When submitted to a profile store, the profile must be assigned a globally uniqu
 
 # Profile Document
 
-ProfileDocument : Description? ProfileName ProfileVersion? Usecase+ NamedModel* NamedField*
+ProfileDocument : Description? ProfileName ProfileVersion Usecase+ NamedModel* NamedField*
 
 ProfileName : `name` = `"` ProfileIdentifier `"`
 
@@ -31,6 +31,7 @@ ProfileVersion : `version` = `"` SemanticVersion `"`
 
 ```example
 name = "meteo/get-weather"
+version = "1.0.0"
 
 usecase GetWeather {
   ...


### PR DESCRIPTION
The version is important for authors and consumers. Making it optional with a `1.0.0` default may create unintended and unnecessary surprises. This also removes a rule that tooling has to deal with.

PS: I'm new to the spec format (which I like!) so please correct me if I'm not following it.