### PR TITLE
chore: add install and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Superface Profile and Map languages specification, research and demos.
 
 ## Develop spec
 
+### Install and setup
+
+```
+$ yarn install
+$ yarn build
+```
+
 ### Profile specification
 
 ```


### PR DESCRIPTION
The watch scripts error out unless you run `yarn build` after you've installed the dependencies.