### PR TITLE
Add provider name to json schema

### DIFF
--- a/spec/draft/provider-spec.yaml
+++ b/spec/draft/provider-spec.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   name:
     type: string
-    pattern: "^[_A-Za-z][_\\-0-9A-Za-z]*$"
+    pattern: "^[a-z][_\\-0-9a-z]*$"
   services:
     type: array
     items:


### PR DESCRIPTION
Provider schema should contain `name` property as defined here: https://www.notion.so/superface/Provider-specification-4e2db3cb2d3a491fb5ee489e33452d30