### PR TITLE
Add service identifier for HTTP calls

### DIFF
--- a/spec/draft/common/definitions.md
+++ b/spec/draft/common/definitions.md
@@ -60,6 +60,10 @@ starwars/character-information@1.1
 
 ProviderIdentifier : DocumentNameIdentifier
 
+## Service Identifier
+
+ServiceIdentifier : Identifier
+
 ## URL Value
 
 URLValue :: `"` URL `"`

--- a/spec/draft/map-spec.md
+++ b/spec/draft/map-spec.md
@@ -383,7 +383,7 @@ NetworkCall :
 
 # HTTP Call
 
-HTTPCall : `http` HTTPMethod URLTemplate { HTTPTransaction }
+HTTPCall : `http` HTTPMethod ServiceIdentifier? URLTemplate { HTTPTransaction }
 
 HTTPMethod : one of GET HEAD POST PUT DELETE CONNECT OPTIONS TRACE PATCH 
 
@@ -418,6 +418,14 @@ map SendMessage {
       }
     }
   }
+}
+```
+
+Example of HTTP call to a service other than the `defaultService`.
+
+```example
+http GET service2 "/users" {
+  ...
 }
 ```
 


### PR DESCRIPTION
This is based on conversations from PR #13. Instead of using variables to point HTTP calls to different services, this introduces a service identifier that explicitly uses a service other than the default service.