### PR TITLE
Providers: allow unverified prefix

### DIFF
--- a/spec/draft/provider-spec.yaml
+++ b/spec/draft/provider-spec.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   name:
     type: string
-    pattern: "^[a-z][_\\-0-9a-z]*$"
+    pattern: "^(unverified\\/)?[a-z][_\\-0-9a-z]*$"
   services:
     type: array
     items:


### PR DESCRIPTION
This PR updates pattern for provider name to allow `unverified/` prefix.