### PR TITLE
Add parameters to provider definition

### DIFF
--- a/spec/draft/provider-spec.yaml
+++ b/spec/draft/provider-spec.yaml
@@ -16,6 +16,13 @@ properties:
   defaultService:
     description: ServiceIdentifier must correspond to existing Service `id` from services.
     $ref: "#/definitions/ServiceIdentifier"
+  parameters:
+    type: array
+    description: |
+      Parameters define user-provided values that may be used within a Comlink Map 
+      or within the provider definition.
+    items:
+      $ref: "#/definitions/Parameter"
 required:
 - name
 - services
@@ -134,3 +141,16 @@ definitions:
     - id
     - type
     - scheme
+  Parameter:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the parameter
+      description:
+        type: string
+      default:
+        type: string
+        description: Default value for the parameter if the user does not provide a value
+    required:
+    - name


### PR DESCRIPTION
This adds parameters to the provider definition for use within the map or the provider definition. It leaves out the parameter type and assumes all parameters are strings for this iteration. It also does not allow the author to specify whether the parameter is required or optional. This would mean every parameter is required unless there's a default value.