### PR TITLE
fix: Provider name cannot contain numbers

### DIFF
--- a/spec/draft/provider-spec.yaml
+++ b/spec/draft/provider-spec.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   name:
     type: string
-    pattern: "^[a-z][_\\-0-9a-z]*$"
+    pattern: "^[a-z][_\\-a-z]*$"
   services:
     type: array
     items:

--- a/spec/latest/provider-spec.yaml
+++ b/spec/latest/provider-spec.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   name:
     type: string
-    pattern: "^[a-z][_\\-0-9a-z]*$"
+    pattern: "^[a-z][_\\-a-z]*$"
   services:
     type: array
     items:


### PR DESCRIPTION
Fixing the pattern in the Provider JSON specification.

We made the decision to ban numbers in the provider names due to security reasons (e.g. `twilio` vs `twi1io`). The [AST implemented the change](https://github.com/superfaceai/ast-js/blob/40a69927292667f965270137c646021992dadeb0/src/interfaces/providerjson/providerjson.schema.json#L24), but we haven't reflected it in the spec.

The pattern is fixed in current latest and upcoming draft.