### PR TITLE
Name document with map spec `Comlink map`

### DIFF
--- a/spec/draft/map-spec.md
+++ b/spec/draft/map-spec.md
@@ -1,5 +1,5 @@
-Superface Map
---------------
+Comlink Map
+-----------
 
 *Current Working Draft*
 

--- a/spec/latest/map-spec.md
+++ b/spec/latest/map-spec.md
@@ -1,5 +1,5 @@
-Superface Map
---------------
+Comlink Map
+-----------
 
 *Version 2022.03.07*
 


### PR DESCRIPTION
Right now we have `Comlink profile` and `Superface map` I believe it should be `Comlink map`. 

And actually in `2021.02.19` and `2021.04.26` it was called `Comlink map`.