### PR TITLE
Required values and correct literals

### DIFF
--- a/spec/draft/profile-spec.md
+++ b/spec/draft/profile-spec.md
@@ -322,7 +322,7 @@ By default all fields are optional. To declare field that is required use {Requi
 
 ```example
 model User {
-  name! string      // the field "name" is required (but can be null)
+  name! string      // the field "name" is required (but can be None)
   email string      // the field "email" is optional
 }
 ```

--- a/spec/draft/profile-spec.md
+++ b/spec/draft/profile-spec.md
@@ -357,7 +357,15 @@ NoneLiteral : `None`
 
 ## Primitive Literal
 
-PrimitiveLiteral : StringValue | NumberLiteral | BooleanLiteral
+PrimitiveLiteral : StringLiteral | NumberLiteral | BooleanLiteral
+
+StringLiteral: `"` CharacterLiteral* `"`
+
+CharacterLiteral ::
+  - SourceCharacter but not `"` or \
+  - \ EscapedCharacter
+
+EscapedCharacter :: one of `"` \ `/` n r t
 
 NumberLiteral: NumberSign? NumberLiteralDigits
 
@@ -397,7 +405,7 @@ LHS : VariableName VariableKeyPath[ObjectVariable]*
 
 VariableName : 
 - Identifier
-- StringValue
+- StringLiteral
 
 VariableKeyPath[ObjectVariable] : `.`VariableName
 

--- a/spec/draft/profile-spec.md
+++ b/spec/draft/profile-spec.md
@@ -346,9 +346,14 @@ ExampleError : error ComlinkLiteral
 ## Comlink Literal
 
 ComlinkLiteral :
+- NoneLiteral
 - PrimitiveLiteral
 - ObjectLiteral
 - ArrayLiteral
+
+## None Literal
+
+NoneLiteral : `None`
 
 ## Primitive Literal
 

--- a/spec/draft/profile-spec.md
+++ b/spec/draft/profile-spec.md
@@ -183,7 +183,7 @@ ModelDefinition :
 
 ModelSpecification: 
 
-- ModelDefinition
+- ModelDefinition RequiredValue?
 - ModelReference
 
 ModelReference : ModelName
@@ -314,9 +314,7 @@ FieldName : Identifier
 
 RequiredField : `!`
 
-FieldSpecification : ModelSpecification RequiredValue?
-
-RequiredValue : `!`
+FieldSpecification : ModelSpecification
 
 ### Required fields
 
@@ -326,17 +324,6 @@ By default all fields are optional. To declare field that is required use {Requi
 model User {
   name! string      // the field "name" is required (but can be null)
   email string      // the field "email" is optional
-}
-```
-
-### Required value
-
-By default all values are optional. To declare value that cannot be null or undefined use {RequiredValue} after {FieldSpecification}
-
-```example
-model User {
-  name string!      // value of name can not be null or undefined
-  email string      // value of email can be null or undefined
 }
 ```
 
@@ -422,6 +409,25 @@ ArrayItemContinued : , ComlinkLiteral
 ## Primitive types
 
 ScalarType : one of boolean string number
+
+## Required value
+
+By default all values are optional. To declare value that cannot be None use {RequiredValue} after {ModelDefinition}
+
+RequiredValue : `!`
+
+```example
+model User {
+  name string!      // value of name cannot be None
+  email string      // value of email can be None
+}
+```
+
+```example
+usecase Example {
+  result string! // result must be of type string
+}
+```
 
 # Language
 

--- a/spec/draft/profile-spec.md
+++ b/spec/draft/profile-spec.md
@@ -316,7 +316,7 @@ RequiredField : `!`
 
 FieldSpecification : ModelSpecification
 
-### Required fields
+### Required field
 
 By default all fields are optional. To declare field that is required use {RequiredField} after {FieldName}
 

--- a/spec/draft/profile-spec.md
+++ b/spec/draft/profile-spec.md
@@ -314,9 +314,9 @@ FieldName : Identifier
 
 RequiredField : `!`
 
-FieldSpecification : ModelSpecification NonNullField?
+FieldSpecification : ModelSpecification RequiredValue?
 
-NonNullField : `!`
+RequiredValue : `!`
 
 ### Required fields
 
@@ -329,14 +329,14 @@ model User {
 }
 ```
 
-### Non-null field value
+### Required value
 
-By default all fields are nullable. To declare field that can be null use {NonNullField} after {FieldSpecification}
+By default all values are optional. To declare value that cannot be null or undefined use {RequiredValue} after {FieldSpecification}
 
 ```example
 model User {
-  name string!      // value of name can not be null
-  email string      // value of email can be null
+  name string!      // value of name can not be null or undefined
+  email string      // value of email can be null or undefined
 }
 ```
 


### PR DESCRIPTION
In this PR is clarified how to work with absent values. 

Related [Decision record](https://www.notion.so/superface/None-type-fc921ac39d764a88ad5ba3b1cc3d148a) _internal_

- fixes nullable/non-nullable value for result
- adds `NoneLiteral` to allow absent values in examples
- adds `StringLiteral` to profiles to avoid confusion