### PR TITLE
Profile error can have zero or one occurrence

### DIFF
--- a/spec/2021.02.19/profile-spec.md
+++ b/spec/2021.02.19/profile-spec.md
@@ -94,7 +94,7 @@ usecase GetWeather {
 
 # Use-case
 
-Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error* }
+Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error? }
 
 UsecaseName: Name
 

--- a/spec/2021.04.26/profile-spec.md
+++ b/spec/2021.04.26/profile-spec.md
@@ -94,7 +94,7 @@ usecase GetWeather {
 
 # Use-case
 
-Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error* }
+Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error? }
 
 UsecaseName: Name
 

--- a/spec/2022.03.07/profile-spec.md
+++ b/spec/2022.03.07/profile-spec.md
@@ -94,7 +94,7 @@ usecase GetWeather {
 
 # Use-case
 
-Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error* Example* }
+Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error? Example* }
 
 UsecaseName: Name
 

--- a/spec/latest/profile-spec.md
+++ b/spec/latest/profile-spec.md
@@ -94,7 +94,7 @@ usecase GetWeather {
 
 # Use-case
 
-Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error* Example* }
+Usecase : Description? `usecase` UsecaseName Safety? { Input? Result? AsyncResult? Error? Example* }
 
 UsecaseName: Name
 


### PR DESCRIPTION
I found out, that the specification allows to have multiple error definitions. From details, I found in internal documents, I never saw even example of multiple errors. So, I am fixing it as a bug in the specification rather not implemented specification.